### PR TITLE
chore(docs): Add links to 2026 referral program editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [ENS Referral Program](https://ensawards.org/ens-referral-program) is an incentive framework designed to distribute awards for referred .eth name registrations and renewals. It is being rolled out as a series of time-limited editions to refine its rules and mechanisms, with the goal of launching a long-term ENS Referral Program.
 
-So far, we have launched the `ENS Holiday Awards` edition (see details [here](https://ensawards.org/ens-referral-program/editions/2025-12/leaderboard)) and are preparing more refined editions for `April 2026` and `May 2026`. Additional details will be announced soon.
+So far, we have launched the `ENS Holiday Awards` edition (see details [here](https://ensawards.org/ens-referral-program/editions/2025-12/leaderboard)) and are preparing more refined editions for [April 2026](https://ensawards.org/ens-referral-program/editions/2026-04/leaderboard) and [May 2026](https://ensawards.org/ens-referral-program/editions/2026-05/leaderboard). Additional details will be announced soon.
 
 These efforts are part of our SPP2 deliverables to the ENS DAO, which include our commitment to ultimately fund $50,000 USD in ENS Referral Program awards throughout the duration of SPP2.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [ENS Referral Program](https://ensawards.org/ens-referral-program) is an incentive framework designed to distribute awards for referred .eth name registrations and renewals. It is being rolled out as a series of time-limited editions to refine its rules and mechanisms, with the goal of launching a long-term ENS Referral Program.
 
-So far, we have launched the `ENS Holiday Awards` edition (see details [here](https://ensawards.org/ens-referral-program/editions/2025-12/leaderboard)) and are preparing more refined editions for [April 2026](https://ensawards.org/ens-referral-program/editions/2026-04/leaderboard) and [May 2026](https://ensawards.org/ens-referral-program/editions/2026-05/leaderboard). Additional details will be announced soon.
+So far, we have launched the `ENS Holiday Awards` edition (see details [here](https://ensawards.org/ens-referral-program/editions/2025-12/leaderboard)), followed by a more refined edition for [April 2026](https://ensawards.org/ens-referral-program/editions/2026-04/leaderboard), and we are now preparing our largest edition yet for [May 2026](https://ensawards.org/ens-referral-program/editions/2026-05/leaderboard). Additional details will be announced soon.
 
 These efforts are part of our SPP2 deliverables to the ENS DAO, which include our commitment to ultimately fund $50,000 USD in ENS Referral Program awards throughout the duration of SPP2.
 


### PR DESCRIPTION
# Lite PR &rarr; Add links to 2026 referral program editions

## Summary

- Updated the readme file of this repository according to [these instructions from Slack](https://namehash.slack.com/archives/C086Z6FNBHN/p1774955685444559).
- Slightly refined the related paragraph to account for the fact that April starts tomorrow (today is 03/31/26)

---

## Why

- Requested by @lightwalker-eth [in this Slack thread](https://namehash.slack.com/archives/C086Z6FNBHN/p1774955685444559)
- Related to the launch of the 2026 April referral program edition and the reveal of the 2026 May edition.

---

## Testing

- Read through the changed parts of the README and asked LLM for support when refining the edited paragraph.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
